### PR TITLE
Fix bug in unitOfWorkMiddleware example

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,16 +261,18 @@ module.exports = function unitOfWorkMiddleware (pool, errorHandler) {
     // responding to the user
     var writeHead = res.writeHead
     res.writeHead = function () {
+       var args = arguments
+
        if (req.tx.state() != 'closed') {
          req.tx.commit(function (err) {
            if (err) {
              errorHandler(req, res, err)
            } else {
-             writeHead.apply(res, arguments)
+             writeHead.apply(res, args)
            }
          })
        } else {
-         writeHead.apply(res, arguments)
+         writeHead.apply(res, args)
        }
     }
     next()


### PR DESCRIPTION
In the case where `req.tx` is committed and succeeds, `res.writeHead`
was called with the arguments to the commit callback function. It should
be called with the arguments that were passed to our version of
`writeHead`.
